### PR TITLE
Add option to use optional kerberos mutual auth or to disable it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,18 @@ Usage
 
 You need to have a valid Kerberos principal, run kinit first if necessary.
 
-Note: Kerberos mutual authentication is set to REQUIRED by default.
-
 .. code-block:: bash
 
     $ http --auth-type=negotiate --auth : https://example.org
+
+
+Kerberos mutual authentication is REQUIRED by default and is recommended.
+If you strictly require mutual authentication to be OPTIONAL or DISBALED, then you can use the ``HTTPIE_KERBEROS_MUTUAL`` environment variable.
+
+.. code-block:: bash
+
+   $ HTTPIE_KERBEROS_MUTUAL=OPTIONAL http --auth-type=negotiate --auth : https://example.org
+   $ HTTPIE_KERBEORS_MUTUAL=DISABLED http --auth-type=negotiate --auth : https://example.org
 
 
 You can also use `HTTPie sessions <https://github.com/jkbr/httpie#sessions>`_:

--- a/httpie_negotiate.py
+++ b/httpie_negotiate.py
@@ -2,6 +2,8 @@
 SPNEGO (GSS Negotiate) auth plugin for HTTPie.
 
 """
+import os
+
 from httpie.plugins import AuthPlugin
 
 
@@ -17,5 +19,14 @@ class NegotiateAuthPlugin(AuthPlugin):
     description = ''
 
     def get_auth(self, username, password):
-        from requests_kerberos import HTTPKerberosAuth
-        return HTTPKerberosAuth()
+        from requests_kerberos import HTTPKerberosAuth, OPTIONAL, DISABLED, REQUIRED
+        pref = os.environ.get("HTTPIE_KERBEROS_MUTUAL")
+        if pref in  ["optional","OPTIONAL"]:
+            kerberos_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        elif pref in ["disabled","DISABLED"]:
+            kerberos_auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
+        elif pref == None or pref in ["required","REQUIRED"]:
+            kerberos_auth = HTTPKerberosAuth()
+        else:
+            raise Exception("Invalid HTTPIE_KEBEROS_MUTUAL value {}".format(pref))
+        return kerberos_auth


### PR DESCRIPTION
Disabling or optionally using Kerberos mutual authentication is
against any best practise and should not be done without a good reason.

In some environments mutual authentication is not properly implemented
and this feature gives you the possibility to disable or optionally use
mutual authentication through an environment variable
HTTPIE_KERBEROS_MUTUAL.